### PR TITLE
Beat Saber 1.6.1 fix

### DIFF
--- a/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
@@ -321,14 +321,14 @@ namespace SongBrowser
             }
             BeatmapLevelPack levelPack = new BeatmapLevelPack(SongBrowserModel.FilteredSongsPackId, packName, selectedLevelPack.shortPackName, selectedLevelPack.coverImage, new BeatmapLevelCollection(sortedSongs.ToArray()));
 
-            TextMeshProUGUI _noDataText = levelCollectionViewController.GetPrivateField<TextMeshProUGUI>("_noDataText");
+            GameObject _noDataGO = levelCollectionViewController.GetPrivateField<GameObject>("_noDataInfoGO");
             //string _headerText = tableView.GetPrivateField<string>("_headerText");
             //Sprite _headerSprite = tableView.GetPrivateField<Sprite>("_headerSprite");
 
             bool _showPlayerStatsInDetailView = navController.GetPrivateField<bool>("_showPlayerStatsInDetailView");
             bool _showPracticeButtonInDetailView = navController.GetPrivateField<bool>("_showPracticeButtonInDetailView");
 
-            navController.SetData(levelPack, true, _showPlayerStatsInDetailView, _showPracticeButtonInDetailView, _noDataText.text);
+            navController.SetData(levelPack, true, _showPlayerStatsInDetailView, _showPracticeButtonInDetailView, _noDataGO);
 
             //_sortedSongs.ForEach(x => Logger.Debug(x.levelID));
         }

--- a/SongBrowserPlugin/SongBrowser.csproj
+++ b/SongBrowserPlugin/SongBrowser.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>

--- a/SongBrowserPlugin/UI/Browser/BeatSaberUIController.cs
+++ b/SongBrowserPlugin/UI/Browser/BeatSaberUIController.cs
@@ -253,8 +253,8 @@ namespace SongBrowser.DataAccess
             Logger.Debug("Scrolling level list to idx: {0}", selectedIndex);
 
             TableView tableView = LevelCollectionTableView.GetPrivateField<TableView>("_tableView");
-
-            if (LevelCollectionTableView.selectedRow != selectedIndex && LevelCollectionTableView.isActiveAndEnabled)
+            var selectedRow = LevelCollectionTableView.GetPrivateField<int>("_selectedRow");
+            if (selectedRow != selectedIndex && LevelCollectionTableView.isActiveAndEnabled)
             {
                 LevelCollectionTableView.HandleDidSelectRowEvent(tableView, selectedIndex);
             }

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -624,11 +624,11 @@ namespace SongBrowser.UI
             Logger.Debug($"Cancelling filter, levelPack {_lastLevelPack}");
             _model.Settings.filterMode = SongFilterMode.None;
 
-            TextMeshProUGUI _noDataText = _beatUi.LevelCollectionViewController.GetPrivateField<TextMeshProUGUI>("_noDataText");
+            GameObject _noDataGO = _beatUi.LevelCollectionViewController.GetPrivateField<GameObject>("_noDataInfoGO");
             string _headerText = _beatUi.LevelCollectionTableView.GetPrivateField<string>("_headerText");
             Sprite _headerSprite = _beatUi.LevelCollectionTableView.GetPrivateField<Sprite>("_headerSprite");
 
-            _beatUi.LevelCollectionViewController.SetData(_lastLevelPack.beatmapLevelCollection, _headerText, _headerSprite, false, _noDataText.text);
+            _beatUi.LevelCollectionViewController.SetData(_lastLevelPack.beatmapLevelCollection, _headerText, _headerSprite, false, _noDataGO);
         }
 
         /// <summary>
@@ -659,7 +659,8 @@ namespace SongBrowser.UI
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
         /// <param name="arg4"></param>
-        private void _levelFilteringNavController_didSelectPackEvent(LevelFilteringNavigationController arg1, IAnnotatedBeatmapLevelCollection arg2, string arg3, BeatmapCharacteristicSO arg4)
+        private void _levelFilteringNavController_didSelectPackEvent(LevelFilteringNavigationController arg1, IAnnotatedBeatmapLevelCollection arg2, 
+            GameObject arg3, BeatmapCharacteristicSO arg4)
         {
             Logger.Trace("_levelFilteringNavController_didSelectPackEvent(levelPack={0})", arg2);
 
@@ -816,11 +817,11 @@ namespace SongBrowser.UI
             }
             else
             {              
-                TextMeshProUGUI _noDataText = _beatUi.LevelCollectionViewController.GetPrivateField<TextMeshProUGUI>("_noDataText");
+                GameObject _noDataGO = _beatUi.LevelCollectionViewController.GetPrivateField<GameObject>("_noDataInfoGO");
                 string _headerText = _beatUi.LevelCollectionTableView.GetPrivateField<string>("_headerText");
                 Sprite _headerSprite = _beatUi.LevelCollectionTableView.GetPrivateField<Sprite>("_headerSprite");
                 
-                _beatUi.LevelCollectionViewController.SetData(_lastLevelPack.beatmapLevelCollection, _headerText, _headerSprite, false, _noDataText.text);
+                _beatUi.LevelCollectionViewController.SetData(_lastLevelPack.beatmapLevelCollection, _headerText, _headerSprite, false, _noDataGO);
             }
 
             // If selecting the same filter, cancel


### PR DESCRIPTION
* LevelSelectionNavigationController.SetData now takes a GameObject instead of a string for the "No Data Text".
* LevelCollectionTableView no longer has a 'selectedRow' property and needs reflection to get the value.
* Changed project PDB type to Portable so IPA's logger can show the line numbers for exceptions.