### PR TITLE
Show correct NJS on stats panel

### DIFF
--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -905,7 +905,7 @@ namespace SongBrowser.UI
                 if (_beatUi.StandardLevelDetailView != null)
                 {
                     RefreshScoreSaberData(_beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.level);
-                    RefreshNoteJumpSpeed(_beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.difficulty);
+                    RefreshNoteJumpSpeed(_beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.noteJumpMovementSpeed);
                 }
             }
             catch (Exception e)
@@ -929,7 +929,7 @@ namespace SongBrowser.UI
             _deleteButton.interactable = (view.selectedDifficultyBeatmap.level.levelID.Length >= 32);
 
             RefreshScoreSaberData(view.selectedDifficultyBeatmap.level);
-            RefreshNoteJumpSpeed(beatmap.difficulty);
+            RefreshNoteJumpSpeed(beatmap.noteJumpMovementSpeed);
         }
 
         /// <summary>
@@ -949,7 +949,7 @@ namespace SongBrowser.UI
             _deleteButton.interactable = (_beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID.Length >= 32);
 
             RefreshScoreSaberData(view.selectedDifficultyBeatmap.level);
-            RefreshNoteJumpSpeed(view.selectedDifficultyBeatmap.difficulty);
+            RefreshNoteJumpSpeed(view.selectedDifficultyBeatmap.noteJumpMovementSpeed);
         }
 
         /// <summary>
@@ -1162,10 +1162,10 @@ namespace SongBrowser.UI
         /// <summary>
         /// Helper to refresh the NJS widget.
         /// </summary>
-        /// <param name="beatmap"></param>
-        private void RefreshNoteJumpSpeed(BeatmapDifficulty beatmap)
+        /// <param name="noteJumpMovementSpeed"></param>
+        private void RefreshNoteJumpSpeed(float noteJumpMovementSpeed)
         {
-            BeatSaberUI.SetStatButtonText(_njsStatButton, String.Format("{0}", beatmap.NoteJumpMovementSpeed()));
+            BeatSaberUI.SetStatButtonText(_njsStatButton, String.Format("{0}", noteJumpMovementSpeed));
         }
 
         /// <summary>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14931856/72198758-c04d2f80-33e6-11ea-9cec-8d3f59cc1cc3.png)

Turns out the NoteJumpMovementSpeed function for the BeatmapDifficulty enum just pulls from a list of predefined values, so instead, take the NJS value from the IDifficultyBeatmap.