### PR TITLE
Fix solo button not working after previewing unowned packs

### DIFF
--- a/SongBrowserPlugin/UI/Browser/BeatSaberUIController.cs
+++ b/SongBrowserPlugin/UI/Browser/BeatSaberUIController.cs
@@ -80,7 +80,7 @@ namespace SongBrowser.DataAccess
             StandardLevelDetailView = LevelDetailViewController.GetPrivateField<StandardLevelDetailView>("_standardLevelDetailView");
             Logger.Debug("Acquired StandardLevelDetailView [{0}]", StandardLevelDetailView.GetInstanceID());
 
-            BeatmapCharacteristicSelectionViewController = LevelDetailViewController.GetComponentInChildren<BeatmapCharacteristicSegmentedControlController>();
+            BeatmapCharacteristicSelectionViewController = StandardLevelDetailView.GetPrivateField<BeatmapCharacteristicSegmentedControlController>("_beatmapCharacteristicSegmentedControlController");
             Logger.Debug("Acquired BeatmapCharacteristicSegmentedControlController [{0}]", BeatmapCharacteristicSelectionViewController.GetInstanceID());
 
             LevelDifficultyViewController = StandardLevelDetailView.GetPrivateField<BeatmapDifficultySegmentedControlController>("_beatmapDifficultySegmentedControlController");
@@ -97,7 +97,7 @@ namespace SongBrowser.DataAccess
             TableViewPageDownButton = tableView.GetPrivateField<Button>("_pageDownButton");
             Logger.Debug("Acquired Page Up and Down buttons...");
 
-            ActionButtons = LevelDetailViewController.GetComponentsInChildren<RectTransform>().First(x => x.name == "ActionButtons");
+            ActionButtons = StandardLevelDetailView.GetComponentsInChildren<RectTransform>().First(x => x.name == "ActionButtons");
             Logger.Debug("Acquired ActionButtons [{0}]", ActionButtons.GetInstanceID());
 
             ScreenSystem = Resources.FindObjectsOfTypeAll<ScreenSystem>().Last();


### PR DESCRIPTION
To reproduce issue:

```
Open beat saber
Click BTS at bottom
Click on a song so preview starts
Click back to main menu
Try to go into solo mode
Note that the button is broken
```

There's a separate issue where the UI doesn't load if you enter via the BTS button without ever using the solo button but that seems a lot more complicated to fix