### PR TITLE
Add support for deleting from WIP and extra folders

### DIFF
--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -937,11 +937,37 @@ namespace SongBrowser.UI
                         try
                         {
                             List<IPreviewBeatmapLevel> levels = _beatUi.GetCurrentLevelCollectionLevels().ToList();
+                            String collection = _beatUi.GetCurrentSelectedAnnotatedBeatmapLevelCollection().collectionName;
                             int selectedIndex = levels.FindIndex(x => x.levelID == _beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.level.levelID);
 
                             if (selectedIndex > -1)
                             {
-                                var song = SongCore.Loader.CustomLevels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                CustomPreviewBeatmapLevel song;
+
+                                if (collection.Equals("Custom Levels"))
+                                {
+                                    song = SongCore.Loader.CustomLevels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                }
+                                else if (collection.Equals("WIP Levels"))
+                                {
+                                    song = SongCore.Loader.CustomWIPLevels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                }
+                                else if (collection.Equals("Cached WIP Levels"))
+                                {
+                                    return;
+                                }
+                                else
+                                {
+                                    var names = SongCore.Loader.SeperateSongFolders.Select(x => x.SongFolderEntry.Name);
+                                    var separateFolders = SongCore.Loader.SeperateSongFolders; 
+                                    if (names.Contains(collection))
+                                    {
+                                        int folder_index = separateFolders.FindIndex(x => x.SongFolderEntry.Name.Equals(collection));
+                                        song = separateFolders[folder_index].Levels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                    }
+                                    else
+                                        throw new Exception("Could not find level path. Is the selected collection a playlist?");
+                                }
 
                                 Logger.Info($"Deleting song: {song.customLevelPath}");
 

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -944,29 +944,29 @@ namespace SongBrowser.UI
                             if (selectedIndex > -1)
                             {
                                 CustomPreviewBeatmapLevel song;
-                                if (collection.Equals("Custom Levels"))
+
+                                switch (collection)
                                 {
-                                    song = SongCore.Loader.CustomLevels.First(x => x.Value.levelID == selectedLevelID).Value;
-                                }
-                                else if (collection.Equals("WIP Levels"))
-                                {
-                                    song = SongCore.Loader.CustomWIPLevels.First(x => x.Value.levelID == selectedLevelID).Value;
-                                }
-                                else if (collection.Equals("Cached WIP Levels"))
-                                {
-                                    return;
-                                }
-                                else
-                                {
-                                    var names = SongCore.Loader.SeperateSongFolders.Select(x => x.SongFolderEntry.Name);
-                                    var separateFolders = SongCore.Loader.SeperateSongFolders; 
-                                    if (names.Contains(collection))
-                                    {
-                                        int folder_index = separateFolders.FindIndex(x => x.SongFolderEntry.Name.Equals(collection));
-                                        song = separateFolders[folder_index].Levels.First(x => x.Value.levelID == selectedLevelID).Value;
-                                    }
-                                    else
-                                        throw new Exception("Could not find level path. Is the selected collection a playlist?");
+                                    case "Custom Levels":
+                                        song = SongCore.Loader.CustomLevels.First(x => x.Value.levelID == selectedLevelID).Value;
+                                        break;
+                                    case "WIP Levels":
+                                        song = SongCore.Loader.CustomWIPLevels.First(x => x.Value.levelID == selectedLevelID).Value;
+                                        break;
+                                    case "Cached WIP Levels":
+                                        throw new Exception("Cannot delete cached levels.");
+                                    default:
+                                        var names = SongCore.Loader.SeperateSongFolders.Select(x => x.SongFolderEntry.Name);
+                                        var separateFolders = SongCore.Loader.SeperateSongFolders;
+
+                                        if (names.Contains(collection))
+                                        {
+                                            int folder_index = separateFolders.FindIndex(x => x.SongFolderEntry.Name.Equals(collection));
+                                            song = separateFolders[folder_index].Levels.First(x => x.Value.levelID == selectedLevelID).Value;
+                                        }
+                                        else
+                                            throw new Exception("Could not find level path. Is the selected collection a playlist?");
+                                        break;
                                 }
 
                                 Logger.Info($"Deleting song: {song.customLevelPath}");

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -938,19 +938,19 @@ namespace SongBrowser.UI
                         {
                             List<IPreviewBeatmapLevel> levels = _beatUi.GetCurrentLevelCollectionLevels().ToList();
                             String collection = _beatUi.GetCurrentSelectedAnnotatedBeatmapLevelCollection().collectionName;
-                            int selectedIndex = levels.FindIndex(x => x.levelID == _beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.level.levelID);
+                            String selectedLevelID = _beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.level.levelID;
+                            int selectedIndex = levels.FindIndex(x => x.levelID == selectedLevelID);
 
                             if (selectedIndex > -1)
                             {
                                 CustomPreviewBeatmapLevel song;
-
                                 if (collection.Equals("Custom Levels"))
                                 {
-                                    song = SongCore.Loader.CustomLevels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                    song = SongCore.Loader.CustomLevels.First(x => x.Value.levelID == selectedLevelID).Value;
                                 }
                                 else if (collection.Equals("WIP Levels"))
                                 {
-                                    song = SongCore.Loader.CustomWIPLevels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                    song = SongCore.Loader.CustomWIPLevels.First(x => x.Value.levelID == selectedLevelID).Value;
                                 }
                                 else if (collection.Equals("Cached WIP Levels"))
                                 {
@@ -963,7 +963,7 @@ namespace SongBrowser.UI
                                     if (names.Contains(collection))
                                     {
                                         int folder_index = separateFolders.FindIndex(x => x.SongFolderEntry.Name.Equals(collection));
-                                        song = separateFolders[folder_index].Levels.First(x => x.Value.levelID == _beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID).Value;
+                                        song = separateFolders[folder_index].Levels.First(x => x.Value.levelID == selectedLevelID).Value;
                                     }
                                     else
                                         throw new Exception("Could not find level path. Is the selected collection a playlist?");
@@ -973,7 +973,7 @@ namespace SongBrowser.UI
 
                                 SongCore.Loader.Instance.DeleteSong(song.customLevelPath);
 
-                                int removedLevels = levels.RemoveAll(x => x.levelID == _beatUi.StandardLevelDetailView.selectedDifficultyBeatmap.level.levelID);
+                                int removedLevels = levels.RemoveAll(x => x.levelID == selectedLevelID);
                                 Logger.Info($"Removed [{removedLevels}] level(s) from song list!");
 
                                 this.UpdateLevelDataModel();


### PR DESCRIPTION
Currently it is not possible to delete levels from the WIP section, or from any extra folders added by SongCore. This pull request will allow players to delete levels from other locations than the main collection.

Any cached WIP levels still cannot be deleted, as there are no level folders associated with them. It also does not allow deleting from playlists added by PlaylistLoaderLite. It might be a good idea to remove the delete button in cached WIP levels and it might be possible to support deleting while in a playlist, though these seem like they would require some more complex changes.

This also changes the levelID in the deletion function to be taken from just the StandardLevelDetailView instead of both the StandardLevelDetailView and the LevelDetailViewController, as they appear to always be equal. 