### PR TITLE
Add filter for mods requirements

### DIFF
--- a/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
@@ -249,8 +249,8 @@ namespace SongBrowser
                 case SongFilterMode.Unranked:
                     filteredSongs = FilterRanked(unsortedSongs, false, true);
                     break;
-                case SongFilterMode.Mods:
-                    filteredSongs = FilterMods(unsortedSongs);
+                case SongFilterMode.Requirements:
+                    filteredSongs = FilterRequirements(unsortedSongs);
                     break;
                 case SongFilterMode.Custom:
                     Logger.Info("Song filter mode set to custom. Deferring filter behaviour to another mod.");
@@ -458,7 +458,7 @@ namespace SongBrowser
         /// </summary>
         /// <param name="levels"></param>
         /// <returns></returns>
-        private List<IPreviewBeatmapLevel> FilterMods(List<IPreviewBeatmapLevel> levels)
+        private List<IPreviewBeatmapLevel> FilterRequirements(List<IPreviewBeatmapLevel> levels)
         {
             return levels.Where(x =>
             {

--- a/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
@@ -460,25 +460,25 @@ namespace SongBrowser
         /// <returns></returns>
         private List<IPreviewBeatmapLevel> FilterMods(List<IPreviewBeatmapLevel> levels)
         {
-          return levels.Where(x =>
-          {
-            if (x is CustomPreviewBeatmapLevel customLevel)
+            return levels.Where(x =>
             {
-              var saveData = customLevel.standardLevelInfoSaveData as CustomLevelInfoSaveData;
-
-              foreach (CustomLevelInfoSaveData.DifficultyBeatmapSet difficulties in saveData.difficultyBeatmapSets)
-              {
-                foreach (CustomLevelInfoSaveData.DifficultyBeatmap difficulty in difficulties.difficultyBeatmaps)
+                if (x is CustomPreviewBeatmapLevel customLevel)
                 {
-                  List<object> requirements = CustomJSONData.Trees.at(difficulty.customData, "_requirements");
+                    var saveData = customLevel.standardLevelInfoSaveData as CustomLevelInfoSaveData;
 
-                  return requirements != null && requirements.Count > 0;
+                    foreach (CustomLevelInfoSaveData.DifficultyBeatmapSet difficulties in saveData.difficultyBeatmapSets)
+                    {
+                        foreach (CustomLevelInfoSaveData.DifficultyBeatmap difficulty in difficulties.difficultyBeatmaps)
+                        {
+                            List<object> requirements = CustomJSONData.Trees.at(difficulty.customData, "_requirements");
+
+                            return requirements != null && requirements.Count > 0;
+                        }
+                    }
                 }
-              }
-            }
 
-            return false;
-          }).ToList();
+                return false;
+            }).ToList();
         }
 
         /// <summary>

--- a/SongBrowserPlugin/DataAccess/SongBrowserSettings.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserSettings.cs
@@ -64,6 +64,7 @@ namespace SongBrowser.DataAccess
         Search,
         Ranked,
         Unranked,
+        Mods,
 
         // For other mods that extend SongBrowser
         Custom

--- a/SongBrowserPlugin/DataAccess/SongBrowserSettings.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserSettings.cs
@@ -64,7 +64,7 @@ namespace SongBrowser.DataAccess
         Search,
         Ranked,
         Unranked,
-        Mods,
+        Requirements,
 
         // For other mods that extend SongBrowser
         Custom

--- a/SongBrowserPlugin/SongBrowser.csproj
+++ b/SongBrowserPlugin/SongBrowser.csproj
@@ -30,6 +30,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Reference Include="CustomJSONData">
+          <HintPath>$(BeatSaberDir)\Plugins\CustomJSONData.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.CSharp" />
         <Reference Include="Unity.TextMeshPro">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
             <Private>False</Private>

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -336,12 +336,12 @@ namespace SongBrowser.UI
 
             string[] filterButtonNames = new string[]
             {
-                    "Search", "Ranked", "Unranked", "Mods"
+                    "Search", "Ranked", "Unranked", "Requirements"
             };
 
             SongFilterMode[] filterModes = new SongFilterMode[]
             {
-                    SongFilterMode.Search, SongFilterMode.Ranked, SongFilterMode.Unranked, SongFilterMode.Mods
+                    SongFilterMode.Search, SongFilterMode.Ranked, SongFilterMode.Unranked, SongFilterMode.Requirements
             };
 
             _filterButtonGroup = new List<SongFilterButton>();

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -336,12 +336,12 @@ namespace SongBrowser.UI
 
             string[] filterButtonNames = new string[]
             {
-                    "Search", "Ranked", "Unranked"
+                    "Search", "Ranked", "Unranked", "Mods"
             };
 
             SongFilterMode[] filterModes = new SongFilterMode[]
             {
-                    SongFilterMode.Search, SongFilterMode.Ranked, SongFilterMode.Unranked
+                    SongFilterMode.Search, SongFilterMode.Ranked, SongFilterMode.Unranked, SongFilterMode.Mods
             };
 
             _filterButtonGroup = new List<SongFilterButton>();

--- a/SongBrowserPlugin/manifest.json
+++ b/SongBrowserPlugin/manifest.json
@@ -10,7 +10,7 @@
     "SongCore": "^3.0.0",
     "SongDataCore": "^1.3.5",
     "BSIPA": "^4.1.3",
-    "BeatSaberMarkupLanguage": "^1.4.5",
+    "BeatSaberMarkupLanguage": "^1.5.1",
     "CustomJSONData": "^1.1.3"
   },
   "misc": {

--- a/SongBrowserPlugin/manifest.json
+++ b/SongBrowserPlugin/manifest.json
@@ -10,7 +10,8 @@
     "SongCore": "^3.0.0",
     "SongDataCore": "^1.3.5",
     "BSIPA": "^4.1.3",
-    "BeatSaberMarkupLanguage": "^1.4.5"
+    "BeatSaberMarkupLanguage": "^1.4.5",
+    "CustomJSONData": "^1.1.3"
   },
   "misc": {
     "plugin-hint": "SongBrowser.Plugin"

--- a/SongBrowserPlugin/manifest.json
+++ b/SongBrowserPlugin/manifest.json
@@ -11,7 +11,7 @@
     "SongDataCore": "^1.3.7",
     "BSIPA": "^4.1.3",
     "BeatSaberMarkupLanguage": "^1.5.1",
-    "CustomJSONData": "^1.1.3"
+    "CustomJSONData": "^1.1.4"
   },
   "misc": {
     "plugin-hint": "SongBrowser.Plugin"


### PR DESCRIPTION
This adds a new filter for mods requirements, so you can easily find all wall maps and the like that rely on Chroma, Noodle Extensions, and Mapping Extensions.

This PR adds CustomJSONData as a dependency, so it's up to you to decide if this is something that bothers you or not.

Closes #147