### PR TITLE
Compatibility for upcoming PlaylistManager

### DIFF
--- a/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
@@ -233,7 +233,7 @@ namespace SongBrowser
             }
 
             Logger.Debug($"Using songs from level collection: {selectedBeatmapCollection.collectionName} [num={selectedBeatmapCollection.beatmapLevelCollection.beatmapLevels.Length}");
-            unsortedSongs = selectedBeatmapCollection.beatmapLevelCollection.beatmapLevels.ToList();
+            unsortedSongs = GetLevelsForLevelCollection(selectedBeatmapCollection).ToList();
 
             // filter
             Logger.Debug($"Starting filtering songs by {_settings.filterMode}");
@@ -822,6 +822,19 @@ namespace SongBrowser
         {
             var split = levelId.Split('_');
             return split.Length > 2 ? split[2] : levelId;
+        }
+
+        public static IPreviewBeatmapLevel[] GetLevelsForLevelCollection(IAnnotatedBeatmapLevelCollection levelCollection)
+        {
+            if (levelCollection is BeatSaberPlaylistsLib.Legacy.LegacyPlaylist legacyPlaylist)
+            {
+                return legacyPlaylist.BeatmapLevels;
+            }
+            if (levelCollection is BeatSaberPlaylistsLib.Blist.BlistPlaylist blistPlaylist)
+            {
+                return blistPlaylist.BeatmapLevels;
+            }
+            return levelCollection.beatmapLevelCollection.beatmapLevels;
         }
         #endregion
     }

--- a/SongBrowserPlugin/SongBrowser.csproj
+++ b/SongBrowserPlugin/SongBrowser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
+        <TargetFramework>net48</TargetFramework>
         <OutputType>Library</OutputType>
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
@@ -30,6 +30,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Reference Include="BeatSaberPlaylistsLib">
+          <HintPath>$(BeatSaberDir)\Libs\BeatSaberPlaylistsLib.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
         <Reference Include="CustomJSONData">
           <HintPath>$(BeatSaberDir)\Plugins\CustomJSONData.dll</HintPath>
           <Private>False</Private>

--- a/SongBrowserPlugin/UI/Browser/BeatSaberUIController.cs
+++ b/SongBrowserPlugin/UI/Browser/BeatSaberUIController.cs
@@ -132,13 +132,7 @@ namespace SongBrowser.DataAccess
         /// <returns></returns>
         public IAnnotatedBeatmapLevelCollection GetCurrentSelectedAnnotatedBeatmapLevelCollection()
         {
-            IAnnotatedBeatmapLevelCollection collection = GetCurrentSelectedLevelPack();
-            if (collection == null)
-            {
-                collection = GetCurrentSelectedPlaylist();
-            }
-
-            return collection;
+            return AnnotatedBeatmapLevelCollectionsViewController.selectedAnnotatedBeatmapLevelCollection;
         }
 
         /// <summary>
@@ -206,8 +200,7 @@ namespace SongBrowser.DataAccess
                 Logger.Debug("Current selected level collection is null for some reason...");
                 return null;
             }
-
-            return levelCollection.beatmapLevelCollection.beatmapLevels;
+            return SongBrowserModel.GetLevelsForLevelCollection(levelCollection);
         }
 
         public bool SelectLevelCategory(String levelCategoryName)

--- a/SongBrowserPlugin/manifest.json
+++ b/SongBrowserPlugin/manifest.json
@@ -12,6 +12,7 @@
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.4.9",
     "BeatSaberMarkupLanguage": "^1.5.1",
+    "BeatSaberPlaylistsLib": "^1.3.0",
     "CustomJSONData": "^1.1.4"
   },
   "misc": {


### PR DESCRIPTION
The upcoming PlaylistManager (and BeatSaberPlaylistsLib) will be using a new way of loading levels into the game to make them more transparent to other mods (as playlist songs are their own type with their own unique data and PlaylistManager needs to access it). As a result, SongBrowser will need to get the songs directly as PlaylistSongs to maintain compatibility. DM me on Discord if you have any questions.