### PR TITLE
Fixed ReflectionUtil reference

### DIFF
--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -2,7 +2,6 @@
 using HMUI;
 using SongBrowser.DataAccess;
 using SongBrowser.Internals;
-using SongCore.Utilities;
 using SongDataCore.BeatStar;
 using System;
 using System.Collections;
@@ -546,8 +545,8 @@ namespace SongBrowser.UI
 
             yield return new WaitForEndOfFrame();
 
-            var tv = _beatUi.LevelCollectionTableView.GetField<TableView>("_tableView");
-            var sv = tv.GetField<ScrollView>("_scrollView");
+            var tv = _beatUi.LevelCollectionTableView.GetField<TableView, LevelCollectionTableView>("_tableView");
+            var sv = tv.GetField<ScrollView, TableView>("_scrollView");
             Logger.Debug($"Force scrolling to {position}");
             sv.ScrollTo(position, false);
         }
@@ -988,8 +987,8 @@ namespace SongBrowser.UI
             }
 
             // stash the scroll index
-            var tv = _beatUi.LevelCollectionTableView.GetField<TableView>("_tableView");
-            var sv = tv.GetField<ScrollView>("_scrollView");
+            var tv = _beatUi.LevelCollectionTableView.GetField<TableView, LevelCollectionTableView>("_tableView");
+            var sv = tv.GetField<ScrollView, TableView>("_scrollView");
             _model.LastScrollIndex = sv.position;
 
             UpdateDeleteButtonState(_beatUi.LevelDetailViewController.selectedDifficultyBeatmap.level.levelID);

--- a/SongBrowserPlugin/manifest.json
+++ b/SongBrowserPlugin/manifest.json
@@ -7,7 +7,7 @@
   "name": "Song Browser",
   "version": "6.2.0",
   "dependsOn": {
-    "SongCore": "^3.4.0",
+    "SongCore": "^3.5.0",
     "SongDataCore": "^1.3.8",
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.4.9",


### PR DESCRIPTION
It was accidentally relying on SongCore's built-in ReflectionUtil, which is now removed in favor of BSIPA's ReflectionUtil.
Currently targeted your `devel` branch, but feel free to change that to `master` when needed.