### PR TITLE
Fix requirements filter and make it optional

### DIFF
--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -120,7 +120,7 @@ namespace SongBrowser.UI
             }
             else
             {
-                Logger.Info("Entering Unsupported mode...");                
+                Logger.Info("Entering Unsupported mode...");
                 return;
             }
 
@@ -380,6 +380,11 @@ namespace SongBrowser.UI
                 filterButton.Button.SetButtonTextSize(filterButtonFontSize);
                 filterButton.Button.ToggleWordWrapping(false);
 
+                if (i == 3 && IPA.Loader.PluginManager.EnabledPlugins.All(p => p.Name != "CustomJSONData"))
+                {
+                    filterButton.Button.interactable = false;
+                }
+
                 _filterButtonGroup.Add(filterButton);
             }
         }
@@ -440,7 +445,7 @@ namespace SongBrowser.UI
             (statsPanel.transform as RectTransform).Translate(0, 0.05f, 0);
 
             _ppStatButton = BeatSaberUI.CreateStatIcon("PPStatLabel",
-                statsPanel.GetComponentsInChildren<RectTransform>().First(x => x.name == "NPS"), 
+                statsPanel.GetComponentsInChildren<RectTransform>().First(x => x.name == "NPS"),
                 statsPanel.transform,
                 Base64Sprites.GraphIcon,
                 "PP Value");
@@ -1473,7 +1478,7 @@ namespace SongBrowser.UI
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public void RefreshSongList()
         {

--- a/SongBrowserPlugin/manifest.json
+++ b/SongBrowserPlugin/manifest.json
@@ -12,9 +12,11 @@
     "BSIPA": "^4.1.3",
     "BS Utils": "^1.4.9",
     "BeatSaberMarkupLanguage": "^1.5.1",
-    "BeatSaberPlaylistsLib": "^1.3.0",
-    "CustomJSONData": "^1.1.4"
+    "BeatSaberPlaylistsLib": "^1.3.0"
   },
+  "loadAfter": [
+    "CustomJSONData"
+  ],
   "misc": {
     "plugin-hint": "SongBrowser.Plugin"
   }


### PR DESCRIPTION
Currently, the filter isn't filtering songs that have requirements based on map difficulties or characteristics. This fixes this.
It also makes CustomJSONData an optional dependency and disables the button if it isn't installed.