### PR TITLE
Remember and scroll to last selected level for each collection

### DIFF
--- a/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserModel.cs
@@ -1,4 +1,4 @@
-﻿using SongBrowser.DataAccess;
+using SongBrowser.DataAccess;
 using SongCore.Utilities;
 using System;
 using System.Collections.Concurrent;
@@ -64,6 +64,10 @@ namespace SongBrowser
             set
             {
                 _settings.currentLevelId = value;
+                if (_settings.currentLevelCollectionName != null && value != null)
+                {
+                    this.SaveLastSelectedLevelId(_settings.currentLevelCollectionName, value);
+                }
                 _settings.Save();
             }
         }
@@ -190,6 +194,58 @@ namespace SongBrowser
         public void RemoveSongFromLevelCollection(IAnnotatedBeatmapLevelCollection levelCollection, String levelId)
         {
             levelCollection.beatmapLevelCollection.beatmapLevels.ToList().RemoveAll(x => x.levelID == levelId);
+        }
+
+        /// <summary>
+        /// Save last selected levelId separately for each collection.
+        /// </summary>
+        /// <param name="collectionName"></param>
+        /// <param name="levelId"></param>
+        public void SaveLastSelectedLevelId(String collectionName, String levelId)
+        {
+            var lastIds = _settings.lastSelectedLevelIds;
+            var found = false;
+
+            if (lastIds.Count > 0)
+            {
+                foreach (var collection in lastIds)
+                {
+                    if (collection.name == collectionName)
+                    {
+                        collection.levelId = levelId;
+                        found = true;
+                    }
+                }
+            }
+
+            if (lastIds.Count == 0 || !found)
+            {
+                _settings.lastSelectedLevelIds.Add(
+                    new Collection() { name = collectionName, levelId = levelId }
+                );
+            }
+        }
+
+        /// <summary>
+        /// Find last selected levelId for specific collection.
+        /// </summary>
+        /// <param name="collectionName"></param>
+        public string FindLastSelectedLevelId(String collectionName)
+        {
+            var lastIds = _settings.lastSelectedLevelIds;
+
+            if (lastIds.Count > 0)
+            {
+                foreach (var collection in lastIds)
+                {
+                    if (collection.name == collectionName)
+                    {
+                        return collection.levelId;
+                    }
+                }
+            }
+
+            return "";
         }
 
         /// <summary>

--- a/SongBrowserPlugin/DataAccess/SongBrowserSettings.cs
+++ b/SongBrowserPlugin/DataAccess/SongBrowserSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -73,6 +73,16 @@ namespace SongBrowser.DataAccess
     }
 
     [Serializable]
+    public class Collection
+    {
+        [XmlAttribute]
+        public string name;
+
+        [XmlText]
+        public string levelId;
+    }
+
+    [Serializable]
     public class SongBrowserSettings
     {
         public static readonly Encoding Utf8Encoding = Encoding.UTF8;
@@ -96,6 +106,8 @@ namespace SongBrowser.DataAccess
         public int randomSongSeed;
         public bool invertSortResults = false;
 
+        public List<Collection> lastSelectedLevelIds = default(List<Collection>);
+
         [XmlIgnore]
         [NonSerialized]
         public bool DisableSavingSettings = false;
@@ -106,6 +118,7 @@ namespace SongBrowser.DataAccess
         public SongBrowserSettings()
         {
             searchTerms = new List<string>();
+            lastSelectedLevelIds = new List<Collection>();
         }
 
         /// <summary>
@@ -277,7 +290,7 @@ namespace SongBrowser.DataAccess
             {
                 OmitXmlDeclaration = false,
                 Indent = true,
-                NewLineOnAttributes = true,
+                NewLineOnAttributes = false,
                 NewLineHandling = System.Xml.NewLineHandling.Entitize
             };
 

--- a/SongBrowserPlugin/SongBrowser.csproj
+++ b/SongBrowserPlugin/SongBrowser.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
@@ -31,7 +31,7 @@
 
     <ItemGroup>
         <Reference Include="0Harmony">
-          <HintPath>D:\Games\Steam\SteamApps\common\Beat Saber\Libs\0Harmony.dll</HintPath>
+          <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="BeatSaberPlaylistsLib">
           <HintPath>$(BeatSaberDir)\Libs\BeatSaberPlaylistsLib.dll</HintPath>

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -1,4 +1,4 @@
-﻿using BeatSaberMarkupLanguage.Components;
+using BeatSaberMarkupLanguage.Components;
 using HMUI;
 using SongBrowser.DataAccess;
 using SongBrowser.Internals;
@@ -739,11 +739,21 @@ namespace SongBrowser.UI
                     Model.Settings.currentLevelCategoryName = _beatUi.LevelFilteringNavigationController.selectedLevelCategory.ToString();
                 }
 
-                // reset level selection
-                _model.LastSelectedLevelId = null;
-
                 // save level collection
                 this._model.Settings.currentLevelCollectionName = levelCollection.collectionName;
+
+                // set/reset level selection
+                var lastId = _model.FindLastSelectedLevelId(levelCollection.collectionName);
+                if (lastId != "")
+                {
+                    _model.LastSelectedLevelId = lastId;
+                }
+                else
+                {
+                    _model.LastSelectedLevelId = null;
+                }
+
+                // save xml settings file
                 this._model.Settings.Save();
 
                 StartCoroutine(ProcessSongListEndOfFrame());
@@ -764,7 +774,7 @@ namespace SongBrowser.UI
             yield return new WaitForEndOfFrame();
 
             bool scrollToLevel = true;
-            if (_lastLevelCollection != null && _lastLevelCollection as IPlaylist != null)
+            if (_model.LastSelectedLevelId == null)
             {
                 scrollToLevel = false;
                 _model.Settings.sortMode = SongSortMode.Original;


### PR DESCRIPTION
Automatically navigates to the last selected level when you switch between playlists/collections (instead of resetting them to the first position), which helps when you have long playlists and don't want to remember where you stopped yesterday.

IDs are saved in settings.xml in this form:
```xml
  <lastSelectedLevelIds>
    <Collection name="Custom Levels">custom_level_D6BC145A2821E33FD68665DDBE7033FEF820335A</Collection>
    <Collection name="Artistic Walls Vol. 1">custom_level_65C0C3E82499281F2C9B1D09D7EB3E60BCACD57D</Collection>
    <Collection name="Noodlegames">custom_level_ECF0DF1A5D53E42BBAA1A992B9B16D4A979838C8</Collection>
    <Collection name="NoodleJams Vol.1">custom_level_548CC2F2666D123CD9103E62523B6C37C4CB04F5</Collection>
  </lastSelectedLevelIds>
```
P.S. This is my first contribution to any BS mod and I don't really know C# and OOP well 😅
Feel free to comment what needs to be changed or decline if you don't think such functionality is needed.