### PR TITLE
Store Song date in separate file to preserve newest sorting after moving files

### DIFF
--- a/SongBrowserPlugin/Configuration/SongMetadata.cs
+++ b/SongBrowserPlugin/Configuration/SongMetadata.cs
@@ -1,0 +1,31 @@
+﻿using IPA.Config.Stores.Attributes;
+using IPA.Config.Stores.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SongBrowser.Configuration
+{
+    internal class SongMetadataStore
+    {
+        public static SongMetadataStore Instance { get; set; }
+        [UseConverter(typeof(DictionaryConverter<SongMetadata>))]
+        [NonNullable]
+        public virtual Dictionary<string, SongMetadata> Songs { get; set; } = new Dictionary<string, SongMetadata>();
+
+        public virtual SongMetadata GetMetadataForLevelID(string levelID)
+        {
+            if (!Songs.ContainsKey(levelID))
+                SongMetadataStore.Instance.Songs.Add(levelID, new SongMetadata());
+            return Songs[levelID];
+        }
+    }
+
+    internal class SongMetadata
+    {
+        [UseConverter]
+        public virtual DateTime? AddedAt { get; set; }
+    }
+}

--- a/SongBrowserPlugin/Plugin.cs
+++ b/SongBrowserPlugin/Plugin.cs
@@ -39,6 +39,7 @@ namespace SongBrowser
         public void InitWithConfig(Config conf)
         {
             Configuration.PluginConfig.Instance = conf.Generated<Configuration.PluginConfig>();
+            Configuration.SongMetadataStore.Instance = Config.GetConfigFor(nameof(SongBrowser) + "SongMetadata").Generated<Configuration.SongMetadataStore>();
             Log.Debug("Config loaded");
         }
         #endregion


### PR DESCRIPTION
Song AddedAt date is now stored in a separate SongMetadata config file to preserve date after moving the game to a different directory or drive. The "Newest" sorting now keeps working.

File is stored at `UserData/SongBrowserSongMetadata.json`

Fixes #74