### PR TITLE
Implement Vanilla Sorting Mode (sort custom songs in alphabetical order of level paths)

### DIFF
--- a/SongBrowserPlugin/Configuration/SongSortMode.cs
+++ b/SongBrowserPlugin/Configuration/SongSortMode.cs
@@ -24,6 +24,7 @@ namespace SongBrowser.Configuration
         Stars,
         Bpm,
         Length,
+        Vanilla,
 
         // Allow mods to extend functionality.
         Custom,

--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -311,6 +311,7 @@ namespace SongBrowser.UI
                 new KeyValuePair<string, SongSortMode>("Author", SongSortMode.Author),
                 new KeyValuePair<string, SongSortMode>("Mapper", SongSortMode.Mapper),
                 new KeyValuePair<string, SongSortMode>("Newest", SongSortMode.Newest),
+                new KeyValuePair<string, SongSortMode>("Vanilla", SongSortMode.Vanilla),
                 new KeyValuePair<string, SongSortMode>("#Plays", SongSortMode.YourPlayCount),
                 new KeyValuePair<string, SongSortMode>("BPM", SongSortMode.Bpm),
                 new KeyValuePair<string, SongSortMode>("Time", SongSortMode.Length),


### PR DESCRIPTION
After digging around a bit more I found that the FileSystem information *is* available after all.

So here's an implementation for Vanilla sorting.

Resolves #184 

Also: you may want to run your code-formatter over this, since my code style is configured differently from yours.
Preferably, you can generate a `.editorconfig` file that contains all of the formatting rules
[VS reference on .editorconfig files](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022)