### PR TITLE
Maintain Scroll-Position when deleting songs

### DIFF
--- a/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
+++ b/SongBrowserPlugin/UI/Browser/SongBrowserUI.cs
@@ -1137,7 +1137,7 @@ namespace SongBrowser.UI
                                 {
                                     _model.LastSelectedLevelId = levels[selectedIndex].levelID;
                                 }
-                                else if (selectedIndex == levels.Count)
+                                else if (selectedIndex == levels.Count && selectedIndex >= 1)
                                 {
                                     _model.LastSelectedLevelId = levels[selectedIndex - 1].levelID;
                                 }


### PR DESCRIPTION
**Current:**
After a bit of bug-hunting I found that calling `SongCore.Loader.Instance.DeleteSong` will trigger a `didSelectAnnotatedBeatmapLevelCollectionEvent` Event.
Our handler for that event resets the `LastSelectedLevelId` and refreshes the UI.

**Fixed:**
* `RefreshSongList` does not need to be called (otherwise we're performing 2 updates)
* `LastSelectedLevelId` will not be reset when the event is triggered by deleting a song
* When the deleted song was the last of the list, try `index - 1` as the new index

Resolves #158 